### PR TITLE
Support ColumnChart OutputMode

### DIFF
--- a/Benchly.Benchmarks/Md5VsSha256.cs
+++ b/Benchly.Benchmarks/Md5VsSha256.cs
@@ -5,7 +5,7 @@ using System.Security.Cryptography;
 namespace Benchly.Benchmarks
 {
     [BoxPlot(Title = "Box Plot", Colors = "skyblue,slateblue", Height = 800)]
-    [ColumnChart(Title = "Column Chart", Colors = "skyblue,slateblue", Height =800)]
+    [ColumnChart(Title = "Column Chart", Colors = "skyblue,slateblue", Height =800, Output = OutputMode.PerJob)]
     [Histogram(Width=500)]
     [Timeline(Width = 500)]
     [MemoryDiagnoser, SimpleJob(RuntimeMoniker.Net60), SimpleJob(RuntimeMoniker.Net48)]

--- a/Benchly.Benchmarks/Md5VsSha256Params.cs
+++ b/Benchly.Benchmarks/Md5VsSha256Params.cs
@@ -5,7 +5,7 @@ using System.Security.Cryptography;
 namespace Benchly.Benchmarks
 {
     [BoxPlot(Title = "Box Plot")]
-    [ColumnChart(Title = "Column Chart")]
+    [ColumnChart(Title = "Column Chart", Output=OutputMode.Combined)]
     [Histogram]
     [Timeline]
     [MemoryDiagnoser, SimpleJob(RuntimeMoniker.Net60), SimpleJob(RuntimeMoniker.Net48)]

--- a/Benchly.UnitTests/PlotInfoTests.cs
+++ b/Benchly.UnitTests/PlotInfoTests.cs
@@ -1,17 +1,12 @@
 ﻿using FluentAssertions;
 using Plotly.NET;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace Benchly.UnitTests
 {
     public class PlotInfoTests
     {
         [Fact]
-        public void WhenColorIsStringItIsMapped()
+        public void WhenColorIsInvalidStringGetColorsIsEmpty()
         { 
             var info = new PlotInfo();
             info.Colors = "foo";
@@ -19,8 +14,25 @@ namespace Benchly.UnitTests
             var colors = info.GetColors();
 
             colors.Should().NotBeNull();
+            colors.Should().BeEmpty();
+        }
+
+        [Fact]
+        public void WhenColorIsValidStringGetColorsReturnsColor()
+        {
+            var info = new PlotInfo();
+            info.Colors = "firebrick";
+
+            var colors = info.GetColors();
+
+            colors.Should().NotBeNull();
             colors.Length.Should().Be(1);
-            colors[0].Value.Should().Be("foo");
+            var argb = colors[0].Value.Should().BeOfType<ARGB>().Subject;
+
+            argb.A.Should().Be(255);
+            argb.R.Should().Be(178);
+            argb.G.Should().Be(34);
+            argb.B.Should().Be(34);
         }
 
         [Fact]

--- a/Benchly/BoxPlotAttribute.cs
+++ b/Benchly/BoxPlotAttribute.cs
@@ -4,6 +4,27 @@ using BenchmarkDotNet.Exporters;
 namespace Benchly
 {
     /// <summary>
+    /// The chart output mode.
+    /// </summary>
+    public enum OutputMode
+    {
+        /// <summary>
+        /// Output a chart per benchmark method.
+        /// </summary>
+        PerMethod,
+
+        /// <summary>
+        /// Output a chart per benchmark job. This groups methods by job.
+        /// </summary>
+        PerJob,
+
+        /// <summary>
+        /// Output a combined chart, showing all jobs and methods.
+        /// </summary>
+        Combined
+    }
+
+    /// <summary>
     /// Export a box plot.
     /// </summary>
     public sealed class BoxPlotAttribute : PlotBaseAttribute
@@ -58,6 +79,15 @@ namespace Benchly
         {
             get => plotInfo.Colors;
             set => plotInfo.Colors = value;
+        }
+
+        /// <summary>
+        /// Gets or sets the output mode.
+        /// </summary>
+        public OutputMode Output
+        {
+            get => plotInfo.OutputMode;
+            set => plotInfo.OutputMode = value;
         }
 
         /// <summary>

--- a/Benchly/ColorMap.cs
+++ b/Benchly/ColorMap.cs
@@ -5,6 +5,20 @@ namespace Benchly
 {
     internal class ColorMap
     {
+        private static Color[] defaults = new[] { Color.fromKeyword(ColorKeyword.IndianRed), Color.fromKeyword(ColorKeyword.Salmon) };
+
+        internal static Color[] GetColorList(PlotInfo info)
+        {
+            var colors = info.GetColors();
+
+            if (colors.Length == 0)
+            {
+                colors = defaults;
+            }
+
+            return colors;
+        }
+
         internal static Dictionary<string, Color> GetJobColors(Summary summary, PlotInfo info)
         {
             var jobs = summary.Reports.Select(r => r.BenchmarkCase.Job.ResolvedId).Distinct().ToList();
@@ -16,7 +30,7 @@ namespace Benchly
             // give some default colors
             if (colors.Length == 0)
             {
-                colors = new[] { Color.fromKeyword(ColorKeyword.IndianRed), Color.fromKeyword(ColorKeyword.Salmon) };
+                colors = defaults;
             }
 
             for (int i = 0; i < jobs.Count; i++)

--- a/Benchly/ColumnChartExporter.cs
+++ b/Benchly/ColumnChartExporter.cs
@@ -96,7 +96,18 @@ namespace Benchly
                 var title = this.Info.Title ?? summary.Title;
                 var file = Path.Combine(summary.ResultsDirectoryPath, ExporterBase.GetFileName(summary) + "-" + job.Key + "-columnchart");
 
-                Chart2D.Chart.Column<double, string, string, double, double>(job.Select(j => j.mean), job.Select(j => j.name).ToArray(), Name: job.Key)
+                var colors = ColorMap.GetColorList(Info);
+
+                // make 1 chart per column so that we can color by bar index. Legend is disabled since it is not needed.
+                var charts = job
+                    .Select((j, i) => Chart2D.Chart.Column<double, string, string, double, double>(
+                        new[] { j.mean }, 
+                        new[] { j.name }, 
+                        Name: job.Key, 
+                        MarkerColor: colors[i % colors.Length])
+                    .WithLegendGroup(job.Key, false));
+
+                Chart.Combine(charts)
                     .WithAxisTitles("Time (ms)")
                     .WithoutVerticalGridlines()
                     .WithLayout(title)

--- a/Benchly/ColumnChartExporter.cs
+++ b/Benchly/ColumnChartExporter.cs
@@ -1,10 +1,12 @@
 ﻿using BenchmarkDotNet.Exporters;
-using BenchmarkDotNet.Reports;
-using Plotly.NET.ImageExport;
 using BenchmarkDotNet.Loggers;
+using BenchmarkDotNet.Reports;
+
 using Plotly.NET;
+using Plotly.NET.ImageExport;
 using Plotly.NET.LayoutObjects;
 using static Plotly.NET.StyleParam;
+
 using Microsoft.FSharp.Core;
 
 namespace Benchly
@@ -22,24 +24,109 @@ namespace Benchly
                 return Array.Empty<string>();
             }
 
-            if (summary.Reports[0].BenchmarkCase.HasParameters)
+            return Info.OutputMode switch
             {
-                int paramCount = summary.Reports[0].BenchmarkCase.Parameters.Count;
-
-                if (paramCount == 1)
-                {
-                    return OneParameter(summary);
-                }
-            }
-
-            return NoParameter(summary);
+                OutputMode.PerMethod => PerMethod(summary),
+                OutputMode.PerJob => PerJob(summary),
+                OutputMode.Combined => Combined(summary),
+                _ => Array.Empty<string>(),
+            };
         }
 
         public void ExportToLog(Summary summary, ILogger logger)
         {
         }
 
-        private IEnumerable<string> NoParameter(Summary summary)
+        // Revisit this in terms of params:
+        // This would make most sense if used with params, so that you
+        // could look at the results for all param values for each method
+        private IEnumerable<string> PerMethod(Summary summary)
+        {
+            var files = new List<string>();
+
+            foreach (var report in summary.Reports) 
+            {
+                if (!report.Success)
+                {
+                    continue;
+                }
+
+                int paramCount = report.BenchmarkCase.Parameters.Count;
+
+                var title = this.Info.Title ?? summary.Title;
+                var fileSlug = paramCount == 0
+                    ? report.BenchmarkCase.Job.ResolvedId + "-" + report.BenchmarkCase.Descriptor.WorkloadMethodDisplayInfo
+                    : report.BenchmarkCase.Job.ResolvedId + "-" + report.BenchmarkCase.Descriptor.WorkloadMethodDisplayInfo + "-" + report.BenchmarkCase.Parameters.PrintInfo;
+
+                fileSlug += "-columnchart";
+                var file = Path.Combine(summary.ResultsDirectoryPath, ExporterBase.GetFileName(summary) + fileSlug);
+
+                var mean = new[] { ConvertNanosToMs(report.ResultStatistics.Mean) };
+                var name = report.BenchmarkCase.Descriptor.WorkloadMethodDisplayInfo;
+
+                Chart2D.Chart.Column<double, string, string, double, double>(mean, Name: name)
+                    .WithAxisTitles("Time (ms)")
+                    .WithoutVerticalGridlines()
+                    .WithLayout(title)
+                    .SaveSVG(file, Width: Info.Width, Height: Info.Height);
+
+                files.Add(file + ".svg");
+            }
+            return files;
+        }
+        private IEnumerable<string> PerJob(Summary summary)
+        {
+            // don't support params for now
+            if (summary.Reports[0].BenchmarkCase.HasParameters)
+            {
+                return Array.Empty<string>();
+            }
+
+            var files = new List<string>();
+
+            var jobs = summary.Reports.Select(r => new
+            {
+                job = r.BenchmarkCase.Job.ResolvedId,
+                name = r.BenchmarkCase.Descriptor.WorkloadMethodDisplayInfo,
+                mean = r.Success ? ConvertNanosToMs(r.ResultStatistics.Mean) : 0
+            }).GroupBy(r => r.job);
+
+            foreach (var job in jobs)
+            {
+                var title = this.Info.Title ?? summary.Title;
+                var file = Path.Combine(summary.ResultsDirectoryPath, ExporterBase.GetFileName(summary) + "-" + job.Key + "-columnchart");
+
+                Chart2D.Chart.Column<double, string, string, double, double>(job.Select(j => j.mean), job.Select(j => j.name).ToArray(), Name: job.Key)
+                    .WithAxisTitles("Time (ms)")
+                    .WithoutVerticalGridlines()
+                    .WithLayout(title)
+                    .SaveSVG(file, Width: Info.Width, Height: Info.Height);
+
+                files.Add(file + ".svg");
+            }
+
+            return files;
+        }
+
+        private IEnumerable<string> Combined(Summary summary)
+        {
+            if (summary.Reports[0].BenchmarkCase.HasParameters)
+            {
+                int paramCount = summary.Reports[0].BenchmarkCase.Parameters.Count;
+
+                if (paramCount == 1)
+                {
+                    return OneParameterCombined(summary);
+                }
+
+                // we only support 0 or 1 params
+                return Array.Empty<string>();
+            }
+
+            return NoParameterCombined(summary);
+        }
+
+        private IEnumerable<string> NoParameterCombined(Summary summary)
         {
             var title = this.Info.Title ?? summary.Title;
             var file = Path.Combine(summary.ResultsDirectoryPath, ExporterBase.GetFileName(summary) + "-columnchart");
@@ -72,7 +159,7 @@ namespace Benchly
             return new[] { file + ".svg" };
         }
 
-        private IEnumerable<string> OneParameter(Summary summary)
+        private IEnumerable<string> OneParameterCombined(Summary summary)
         {
             var title = this.Info.Title ?? summary.Title;
             var file = Path.Combine(summary.ResultsDirectoryPath, ExporterBase.GetFileName(summary) + "-columnchart");
@@ -112,7 +199,6 @@ namespace Benchly
             }
 
             // https://github.com/plotly/Plotly.NET/issues/387
-            // The alignment of this isn't 100% correct. Another approach may be to give each sub chart an x axis title
             double xWidth = 1.0d / byParam.Count();
             double xMidpoint = xWidth / 2.0d;
             double[] xs = byParam.Select((_, index) => xMidpoint + (xWidth * index)).ToArray();

--- a/Benchly/PlotInfo.cs
+++ b/Benchly/PlotInfo.cs
@@ -12,6 +12,8 @@ namespace Benchly
 
         public int Height { get; set; } = 600;
 
+        public OutputMode OutputMode { get; set; } = OutputMode.Combined;
+
         internal Color[] GetColors()
         {
             if (string.IsNullOrEmpty(Colors))
@@ -38,7 +40,9 @@ namespace Benchly
                 return Color.fromHex(x);
             }
 
-            return Color.fromString(x);
+            var keyword = ColorKeyword.ofKeyWord.Invoke(x);
+            var c = Color.fromKeyword(keyword);
+            return c;
         }
     }
 }


### PR DESCRIPTION
Enable 3 different modes for ColumnChart, giving these output possibilities:

| OutputMode | No Params | 1 Param |
|---------------|---------------|---------|
| PerMethod | File per method | File per method with column per param |
| PerJob | File per job, column per method | File per job with Sub plot per param |
| Combined | 1 file with combined plot | 1 file with sub plot per param |

Example usage:

```cs
    [ColumnChart(Output = OutputMode.PerJob)]
    [MemoryDiagnoser, SimpleJob(RuntimeMoniker.Net60), SimpleJob(RuntimeMoniker.Net48)]
    public class Md5VsSha256
    // ...
```
Combined mode is already implemented.

Not yet implemented:
- PerJob + Params
- PerMethod + Params