### PR TITLE
Extract chart renderer

### DIFF
--- a/Benchly.UnitTests/TestBenchmarkRunner.cs
+++ b/Benchly.UnitTests/TestBenchmarkRunner.cs
@@ -1,6 +1,7 @@
 ﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Columns;
 using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Environments;
 using BenchmarkDotNet.Jobs;
 using BenchmarkDotNet.Reports;
 using BenchmarkDotNet.Running;
@@ -32,7 +33,9 @@ namespace Benchly.UnitTests
         }
     }
 
-    [MemoryDiagnoser, SimpleJob(RuntimeMoniker.Net60), SimpleJob(RuntimeMoniker.Net48)]
+    [MemoryDiagnoser]
+    [DryJob(RuntimeMoniker.Net60)]
+    [DryJob(RuntimeMoniker.Net48)]
     public class Md5VsSha256
     {
         private const int N = 10000;
@@ -55,6 +58,8 @@ namespace Benchly.UnitTests
     }
 
     [MemoryDiagnoser, SimpleJob(RuntimeMoniker.Net60), SimpleJob(RuntimeMoniker.Net48)]
+    [DryJob(RuntimeMoniker.Net60)]
+    [DryJob(RuntimeMoniker.Net48)]
     public class Md5VsSha256Params
     {
         private byte[] data;

--- a/Benchly/ColorMap.cs
+++ b/Benchly/ColorMap.cs
@@ -7,6 +7,15 @@ namespace Benchly
     {
         private static Color[] defaults = new[] { Color.fromKeyword(ColorKeyword.IndianRed), Color.fromKeyword(ColorKeyword.Salmon) };
 
+        internal static void Fill(IEnumerable<TraceInfo> chartData, Color[] colors)
+        {
+            int i = 0;
+            foreach (TraceInfo data in chartData) 
+            {
+                data.MarkerColor = colors[i++ % colors.Length];
+            }
+        }
+
         internal static Color[] GetColorList(PlotInfo info)
         {
             var colors = info.GetColors();

--- a/Benchly/ColumnChartExporter.cs
+++ b/Benchly/ColumnChartExporter.cs
@@ -56,7 +56,6 @@ namespace Benchly
 
                 var columnChartData = new TraceInfo()
                 {
-                    TraceName = null,//report.BenchmarkCase.Job.ResolvedId,
                     Keys = new[] { report.BenchmarkCase.Descriptor.WorkloadMethodDisplayInfo },
                     Values = new[] { report.Success ? ConvertNanosToMs(report.ResultStatistics.Mean) : 0 }
                 };

--- a/Benchly/ColumnChartRenderer.cs
+++ b/Benchly/ColumnChartRenderer.cs
@@ -1,0 +1,107 @@
+﻿using Microsoft.FSharp.Core;
+using Plotly.NET;
+using Plotly.NET.ImageExport;
+using Plotly.NET.LayoutObjects;
+using static Plotly.NET.StyleParam;
+
+namespace Benchly
+{
+    internal class TraceInfo
+    {
+        // these are the values
+        public double[] Values { get; set; }
+
+        // These are the keys for each value
+        public string[] Keys { get; set; }
+
+        // the trace name used for the legend
+        public string TraceName { get; set; } 
+
+        public Color MarkerColor { get; set; }
+    }
+
+    internal class SubPlot
+    {
+        public string Title { get; set; }
+
+        public List<TraceInfo> Traces { get; set; }
+    }
+
+    internal class ColumnChartRenderer
+    {
+        public static void Render(IEnumerable<TraceInfo> traces, string title, string file, int width, int height, bool showLegend)
+        {
+            // TODO: pre-process to determine best units
+
+            var charts = traces
+                        .Select((cd, i) => Chart2D.Chart.Column<double, string, string, double, double>(
+                            cd.Values,
+                            cd.Keys,
+                            Name: cd.TraceName,
+                            MarkerColor: cd.MarkerColor)
+                        .WithLegendGroup(cd.TraceName, showLegend));
+
+            Chart.Combine(charts)
+                    .WithAxisTitles($"Latency (ms)")
+                    .WithoutVerticalGridlines()
+                    .WithLayout(title)
+                    .SaveSVG(file, Width: width, Height: height);
+        }
+
+        public static void Render(IEnumerable<SubPlot> subPlot, string title, string file, int width, int height, Color[] colors)
+        {
+            // TODO: pre-process to determine best units
+
+            // make a grid with 1 row, n columns, where n is number of params
+            // y axis only on first chart
+            var gridCharts = new List<GenericChart.GenericChart>();
+
+            int paramCount = 0;
+            foreach (var plot in subPlot)
+            {
+                ColorMap.Fill(plot.Traces, colors);
+                var charts = new List<GenericChart.GenericChart>();
+
+                // Group the legends, then only show the first for each group
+                // https://stackoverflow.com/questions/60751008/sharing-same-legends-for-subplots-in-plotly
+                foreach (var trace in plot.Traces)
+                {
+                    var chart2 = Chart2D.Chart
+                        .Column<double, string, string, double, double>(trace.Values, trace.Keys, Name: trace.TraceName, MarkerColor: trace.MarkerColor)
+                        .WithLegendGroup(trace.TraceName, paramCount == 0);
+                    charts.Add(chart2);
+                }
+
+                gridCharts.Add(Chart.Combine(charts));
+                paramCount++;
+            }
+
+            // https://github.com/plotly/Plotly.NET/issues/387
+            double xWidth = 1.0d / subPlot.Count();
+            double xMidpoint = xWidth / 2.0d;
+            double[] xs = subPlot.Select((_, index) => xMidpoint + (xWidth * index)).ToArray();
+
+            var annotations = subPlot.Select((p, index) => Annotation.init<double, double, string, string, string, string, string, string, string, string>(
+                X: xs[index],
+                Y: -0.1,
+                XAnchor: StyleParam.XAnchorPosition.Center,
+                ShowArrow: false,
+                YAnchor: StyleParam.YAnchorPosition.Bottom,
+                Text: p.Title.ToString(),
+                XRef: "paper",
+                YRef: "paper"
+            ));
+
+            // this couples all the charts on the same row to have the same y axis
+            var pattern = new FSharpOption<LayoutGridPattern>(LayoutGridPattern.Coupled);
+
+            Chart
+                .Grid<IEnumerable<GenericChart.GenericChart>>(1, subPlot.Count(), Pattern: pattern).Invoke(gridCharts)
+                .WithAnnotations(annotations)
+                .WithoutVerticalGridlines()
+                .WithAxisTitles("Time (ms)")
+                .WithLayout(title)
+                .SaveSVG(file, Width: width, Height: height);
+        }
+    }
+}


### PR DESCRIPTION
Centralize the code that generates charts and separate from the benchmark processing logic, which can now be tested independently.