### PR TITLE
Enable ColumnChart per job with params

### DIFF
--- a/Benchly.Benchmarks/Md5VsSha256.cs
+++ b/Benchly.Benchmarks/Md5VsSha256.cs
@@ -5,7 +5,7 @@ using System.Security.Cryptography;
 namespace Benchly.Benchmarks
 {
     [BoxPlot(Title = "Box Plot", Colors = "skyblue,slateblue", Height = 800)]
-    [ColumnChart(Title = "Column Chart", Colors = "skyblue,slateblue", Height =800, Output = OutputMode.PerJob)]
+    [ColumnChart(Title = "Column Chart ({JOB})", Colors = "skyblue,slateblue", Height =800, Output = OutputMode.PerJob)]
     [Histogram(Width=500)]
     [Timeline(Width = 500)]
     [MemoryDiagnoser, SimpleJob(RuntimeMoniker.Net60), SimpleJob(RuntimeMoniker.Net48)]

--- a/Benchly.Benchmarks/Md5VsSha256Params.cs
+++ b/Benchly.Benchmarks/Md5VsSha256Params.cs
@@ -5,10 +5,10 @@ using System.Security.Cryptography;
 namespace Benchly.Benchmarks
 {
     [BoxPlot(Title = "Box Plot")]
-    [ColumnChart(Title = "Column Chart ({JOB})", Output=OutputMode.Combined)]
+    [ColumnChart(Title = "Column Chart ({JOB})", Output=OutputMode.PerJob)]
     [Histogram]
     [Timeline]
-    [MemoryDiagnoser, SimpleJob(RuntimeMoniker.Net60)]
+    [MemoryDiagnoser, SimpleJob(RuntimeMoniker.Net60), SimpleJob(RuntimeMoniker.Net48)]
     public class Md5VsSha256Params
     {
         private byte[] data;

--- a/Benchly.Benchmarks/Md5VsSha256Params.cs
+++ b/Benchly.Benchmarks/Md5VsSha256Params.cs
@@ -5,10 +5,10 @@ using System.Security.Cryptography;
 namespace Benchly.Benchmarks
 {
     [BoxPlot(Title = "Box Plot")]
-    [ColumnChart(Title = "Column Chart", Output=OutputMode.Combined)]
+    [ColumnChart(Title = "Column Chart ({JOB})", Output=OutputMode.Combined)]
     [Histogram]
     [Timeline]
-    [MemoryDiagnoser, SimpleJob(RuntimeMoniker.Net60), SimpleJob(RuntimeMoniker.Net48)]
+    [MemoryDiagnoser, SimpleJob(RuntimeMoniker.Net60)]
     public class Md5VsSha256Params
     {
         private byte[] data;

--- a/Benchly/ColumnChartExporter.cs
+++ b/Benchly/ColumnChartExporter.cs
@@ -46,7 +46,7 @@ namespace Benchly
 
                 int paramCount = report.BenchmarkCase.Parameters.Count;
 
-                var title = this.Info.Title ?? summary.Title;
+                var title = TitleFormatter.Format(this.Info, summary, report.BenchmarkCase.Job.ResolvedId);
                 var fileSlug = paramCount == 0
                     ? report.BenchmarkCase.Job.ResolvedId + "-" + report.BenchmarkCase.Descriptor.WorkloadMethodDisplayInfo
                     : report.BenchmarkCase.Job.ResolvedId + "-" + report.BenchmarkCase.Descriptor.WorkloadMethodDisplayInfo + "-" + report.BenchmarkCase.Parameters.PrintInfo;
@@ -86,13 +86,13 @@ namespace Benchly
             var colors = ColorMap.GetColorList(Info);
 
             // make 1 chart per column so that we can color by bar index. Legend is disabled since it is not needed.
-            foreach (var chartData in charts)
+            foreach (var chart in charts)
             {
-                var title = this.Info.Title ?? summary.Title;
-                var file = Path.Combine(summary.ResultsDirectoryPath, ExporterBase.GetFileName(summary) + "-" + chartData.Key + "-columnchart");
+                var title = TitleFormatter.Format(this.Info, summary, chart.Key);
+                var file = Path.Combine(summary.ResultsDirectoryPath, ExporterBase.GetFileName(summary) + "-" + chart.Key + "-columnchart");
 
-                ColorMap.Fill(chartData, colors);
-                ColumnChartRenderer.Render(chartData, title, file, Info.Width, Info.Height, false);
+                ColorMap.Fill(chart, colors);
+                ColumnChartRenderer.Render(chart, title, file, Info.Width, Info.Height, false);
 
                 files.Add(file + ".svg");
             }
@@ -120,7 +120,7 @@ namespace Benchly
 
         private IEnumerable<string> NoParameterCombined(Summary summary)
         {
-            var title = this.Info.Title ?? summary.Title;
+            var title = TitleFormatter.Format(this.Info, summary, string.Join(",", summary.Reports.Select(r => r.BenchmarkCase.Job.ResolvedId).Distinct()));
             var file = Path.Combine(summary.ResultsDirectoryPath, ExporterBase.GetFileName(summary) + "-columnchart");
 
             var charts = summary.Reports.Select(r => new
@@ -141,10 +141,19 @@ namespace Benchly
 
         private IEnumerable<string> OneParameterCombined(Summary summary)
         {
-            var title = this.Info.Title ?? summary.Title;
+            var title = TitleFormatter.Format(this.Info, summary, string.Join(",", summary.Reports.Select(r => r.BenchmarkCase.Job.ResolvedId).Distinct()));
             var file = Path.Combine(summary.ResultsDirectoryPath, ExporterBase.GetFileName(summary) + "-columnchart");
 
-            var subPlots = summary.Reports
+            var subPlots = GetSubPlots(summary);
+            var colors = ColorMap.GetColorList(Info);
+            ColumnChartRenderer.Render(subPlots, title, file, Info.Width, Info.Height, colors);
+
+            return new[] { file + ".svg" };
+        }
+
+        private List<SubPlot> GetSubPlots(Summary summary)
+        {
+            return summary.Reports
                 .Select(r => new
                 {
                     param = r.BenchmarkCase.Parameters.PrintInfo,
@@ -158,18 +167,13 @@ namespace Benchly
                     Title = bp.Key,
                     Traces = bp
                         .GroupBy(p => p.job)
-                        .Select(j => new TraceInfo() 
-                        { 
+                        .Select(j => new TraceInfo()
+                        {
                             TraceName = j.Key,
-                            Values = j.Select(j => j.mean).ToArray(), 
+                            Values = j.Select(j => j.mean).ToArray(),
                             Keys = j.Select(j => j.name).ToArray(),
                         }).ToList()
                 }).ToList();
-
-            var colors = ColorMap.GetColorList(Info);
-            ColumnChartRenderer.Render(subPlots, title, file, Info.Width, Info.Height, colors);
-
-            return new[] { file + ".svg" };
         }
     }
 }

--- a/Benchly/ColumnChartRenderer.cs
+++ b/Benchly/ColumnChartRenderer.cs
@@ -52,6 +52,8 @@ namespace Benchly
         {
             var timeUnit = TimeNormalization.Normalize(subPlot.SelectMany(sp => sp.Traces));
 
+            bool singleJob = subPlot.SelectMany(sp => sp.Traces).Select(t => t.TraceName).Distinct().Count() == 1;
+
             // make a grid with 1 row, n columns, where n is number of params
             // y axis only on first chart
             var gridCharts = new List<GenericChart.GenericChart>();
@@ -68,7 +70,7 @@ namespace Benchly
                 {
                     var chart2 = Chart2D.Chart
                         .Column<double, string, string, double, double>(trace.Values, trace.Keys, Name: trace.TraceName, MarkerColor: trace.MarkerColor)
-                        .WithLegendGroup(trace.TraceName, paramCount == 0);
+                        .WithLegendGroup(trace.TraceName, paramCount == 0 && !singleJob);
                     charts.Add(chart2);
                 }
 

--- a/Benchly/TitleFormatter.cs
+++ b/Benchly/TitleFormatter.cs
@@ -1,0 +1,19 @@
+﻿using BenchmarkDotNet.Reports;
+
+namespace Benchly
+{
+    internal class TitleFormatter
+    {
+        public static string Format(PlotInfo Info, Summary summary, string currentJob)
+        {
+            if (!string.IsNullOrEmpty(Info.Title))
+            {
+                var title = Info.Title;
+
+                return title.Replace("{JOB}", currentJob);
+            }
+            
+            return summary.Title;
+        }
+    }
+}


### PR DESCRIPTION
- Consolidate title formatting, enable {JOB} expansion in the title
- Hide legend for single job params
- Enable per job column charts for params as shown below

![Benchly Benchmarks Md5VsSha256Params- NET 6 0-columnchart](https://github.com/bitfaster/benchly/assets/12851828/b9097b95-8279-49d7-ba17-d29fbe65985a)
![Benchly Benchmarks Md5VsSha256Params- NET Framework 4 8-columnchart](https://github.com/bitfaster/benchly/assets/12851828/ec6c9b4e-645f-4ffc-9807-6d077146cee1)
